### PR TITLE
Convert to a more predicable UITap-like handling

### DIFF
--- a/src/IconSelector/IconSelector.swift
+++ b/src/IconSelector/IconSelector.swift
@@ -135,14 +135,23 @@ public class IconSelector: UIControl, UIScrollViewDelegate, UIGestureRecognizerD
 		let highlighted = iconViews.first(where: { $0.isHighlighted })
 
 		guard isEnabled, bounds.contains(containerView.convert(location, to: self)), let iconView = iconView(at: location) else {
-			highlighted?.isHighlighted = false
+            highlighted?.isHighlighted = false
+            gestureRecognizer.isEnabled = false
+            gestureRecognizer.isEnabled = true
 
 			return
 		}
 
 		switch gestureRecognizer.state {
 		case .began, .changed:
-			guard highlighted != iconView, !iconView.isSelected else {
+            guard highlighted == nil || highlighted!.icon.name == iconView.icon.name else {
+                highlighted?.isHighlighted = false
+                gestureRecognizer.isEnabled = false
+                gestureRecognizer.isEnabled = true
+                return
+            }
+            
+            guard !iconView.isSelected else {
 				return
 			}
 


### PR DESCRIPTION
If the user starts to select an icon and then moves their finger over to another, it shouldn't move the selection. It should behave like a UITapGestureRecognizer where the gesture terminates once the touch moves outside of the icon's bounds, requiring a second tap to select said second icon.

This prevents a ton of accidental selections during scroll, too.