### PR TITLE
Disabling App Extensions

### DIFF
--- a/src/IconSelector/Icon.swift
+++ b/src/IconSelector/Icon.swift
@@ -50,6 +50,7 @@ public struct Icon {
 	private weak var bundle: Bundle?
 	
 	/// Gets a flag indicating whether or not this is the currently selected icon
+	@available(iOSApplicationExtension, unavailable)
 	public var isCurrent: Bool {
 		let application = UIApplication.shared
 

--- a/src/IconSelector/IconSelector.swift
+++ b/src/IconSelector/IconSelector.swift
@@ -24,16 +24,13 @@
 
 import UIKit
 
-/** A control that presents available icons and allows selection.
-
-	This control will **not** actually perform any updates
-    based on the user's selection. It is the responsibility
-	of the parent `UIViewController` to perform the update.
-    There are two methods to perform the actual updates.
-    - Read the `selectedIcon` upon the user indicating they're done
-    - Use `addTarget(_:action:for:)` to enroll in updates for the
-      `.valueChanged` event.
-*/
+/// A control that presents available icons and allows selection.
+///
+/// This control will **not** actually perform any updates based on the user's selection. It is the responsibility of
+/// the parent `UIViewController` to perform the update. There are two methods to perform the actual updates.
+/// - Read the `selectedIcon` upon the user indicating they're done.
+/// - Use `addTarget(_:action:for:)` to enroll in updates for the `.valueChanged` event.
+@available(iOSApplicationExtension, unavailable)
 public class IconSelector: UIControl, UIGestureRecognizerDelegate {
 
 	public let icons: [Icon]

--- a/src/IconSelector/IconSelector.swift
+++ b/src/IconSelector/IconSelector.swift
@@ -107,6 +107,11 @@ public class IconSelector: UIControl, UIGestureRecognizerDelegate {
 		gestureRecognizer.addTarget(self, action: #selector(handleGestureRecognizer(_:)))
 		containerView.addGestureRecognizer(gestureRecognizer)
 
+		// This is not ideal. The control should probably not initialize its own state, but in order to avoid a breaking
+		// change I feel like its probably best to allow this for the time being. At least by doing it this way, the
+		// value of the `selectedIcon` property is respected.
+		selectedIcon = UIApplication.shared.alternateIcon
+
 		prepareIconViews()
 	}
 
@@ -362,7 +367,7 @@ public class IconSelector: UIControl, UIGestureRecognizerDelegate {
 			let view = IconView(icon: icon, size: iconSize, borderWidth: selectionStrokeWidth)
 			view.unselectedStrokeColor = unselectedStrokeColor
 			view.shouldDisplayLabel = shouldDisplayLabels
-			view.isSelected = icon.isCurrent
+			view.isSelected = (selectedIcon == icon)
 			return view
 		}
 

--- a/src/IconSelector/IconSelectorViewController.swift
+++ b/src/IconSelector/IconSelectorViewController.swift
@@ -26,6 +26,7 @@ import UIKit
 
 /// A very simple view controller implementation of the `IconSelector`, which can be instantiated to display a custom
 /// collection of icons, or pull the complete list from a given bundle.
+@available(iOSApplicationExtension, unavailable)
 open class IconSelectorViewController: UITableViewController {
 
 	/// The icons displayed by the receiver.

--- a/src/IconSelector/UIApplication.swift
+++ b/src/IconSelector/UIApplication.swift
@@ -30,9 +30,7 @@ extension UIApplication {
 	/// Gets or sets an alternate icon to use
 	public var alternateIcon: Icon? {
 		get {
-			let application = UIApplication.shared
-
-			guard application.supportsAlternateIcons, let name = application.alternateIconName else {
+			guard supportsAlternateIcons, let name = alternateIconName else {
 				return Icon.default
 			}
 
@@ -48,13 +46,11 @@ extension UIApplication {
 	///   - icon: Icon to set; use `nil` to restore the default
 	///   - completionHandler: optional completion handler
 	public func setAlternateIcon(_ icon: Icon?, completionHandler: ((_ error: Swift.Error?) -> Void)? = nil) {
-		let application = UIApplication.shared
-
-		guard application.supportsAlternateIcons else {
+		guard supportsAlternateIcons else {
 			return
 		}
 
-		application.setAlternateIconName(icon?.name, completionHandler: completionHandler)
+		setAlternateIconName(icon?.name, completionHandler: completionHandler)
 	}
 
 }


### PR DESCRIPTION
Some of the newer Xcode betas take issue with using `UIApplication.shared` from app extensions, so I've minimised the use where I can, and marked stuff as unavailable where it would otherwise break things.